### PR TITLE
Refactor streaming demos

### DIFF
--- a/BasicResearchAgency/agency.py
+++ b/BasicResearchAgency/agency.py
@@ -13,6 +13,7 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from agency_swarm import Agency, Agent
 from agents import WebSearchTool
+from demo_utils import stream_demo, copilot_demo
 
 # Basic Research Agent - o4-mini-deep-research with web search
 research_agent = Agent(
@@ -26,94 +27,13 @@ research_agent = Agent(
 agency = Agency(research_agent)
 
 
-async def stream_response(message: str):
-    """Stream a response and handle events properly following streaming.py pattern."""
-    print(f"\n🔥 Streaming: {message}")
-    print("📡 Response: ", end="", flush=True)
-
-    full_text = ""
-
-    async for event in agency.get_response_stream(message):
-        # Handle streaming events with data
-        if hasattr(event, "data"):
-            data = event.data
-
-            # Only capture actual response text, not tool call arguments
-            if hasattr(data, "delta") and hasattr(data, "type"):
-                if data.type == "response.output_text.delta":
-                    # Stream the actual response text in real-time
-                    delta_text = data.delta
-                    if delta_text:
-                        print(delta_text, end="", flush=True)
-                        full_text += delta_text
-                # Skip tool call deltas (we don't want to show those to users)
-                elif data.type == "response.function_call_arguments.delta":
-                    continue
-
-        # Handle validation errors
-        elif isinstance(event, dict):
-            event_type = event.get("event", event.get("type"))
-            if event_type == "error":
-                print(
-                    f"\n❌ Error: {event.get('content', event.get('data', 'Unknown error'))}"
-                )
-                break
-
-    print("\n✅ Stream complete")
-    print(f"📋 Total: {len(full_text)} characters streamed")
-    return full_text
-
-
-async def stream_demo():
-    """Interactive research terminal using proper Agency Swarm streaming."""
-    print("🌟 Basic Research Agency - Deep Research Tool")
-    print("=" * 50)
-    print("Ask any research question. Type 'quit' to exit.\n")
-
-    while True:
-        try:
-            query = input("🔥 Research Query: ").strip()
-            if query.lower() in ["quit", "exit", "q"]:
-                print("👋 Goodbye!")
-                break
-
-            if not query:
-                print("Please enter a research question.")
-                continue
-
-            # Use proper streaming pattern
-            result = await stream_response(query)
-            print("=" * 50)
-
-        except KeyboardInterrupt:
-            print("\n👋 Goodbye!")
-            break
-        except Exception as e:
-            print(f"\n❌ Error: {e}")
-            import traceback
-
-            traceback.print_exc()
-
-
-def copilot_demo():
-    """Launch Copilot UI demo."""
-    try:
-        from agency_swarm.ui.demos.launcher import CopilotDemoLauncher
-
-        launcher = CopilotDemoLauncher()
-        launcher.start(agency)
-    except ImportError:
-        print("❌ Copilot demo requires additional dependencies")
-        print("Install with: pip install agency-swarm[copilot]")
-
-
 if __name__ == "__main__":
     import asyncio
     import sys
 
     if len(sys.argv) > 1 and sys.argv[1] in ["--ui", "--copilot"]:
         print("🚀 Launching Copilot UI...")
-        copilot_demo()
+        copilot_demo(agency)
     else:
         print("🚀 Launching Terminal Demo...")
-        asyncio.run(stream_demo())
+        asyncio.run(stream_demo(agency))

--- a/DeepResearchAgency/agency.py
+++ b/DeepResearchAgency/agency.py
@@ -14,12 +14,15 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 from agency_swarm import Agency, Agent
 from ClarifyingAgent.ClarifyingAgent import ClarifyingAgent
 from InstructionAgent.InstructionAgent import InstructionAgent
 from ResearchAgent.ResearchAgent import ResearchAgent
 from shared_outputs import Clarifications
 from utils import save_research_to_pdf
+from demo_utils import stream_demo, copilot_demo
 
 # ─────────────────────────────────────────────────────────────
 # Process files at application start
@@ -94,269 +97,13 @@ def basic_research(query: str, mock_answers: dict[str, str] | None = None):
     return response
 
 
-async def stream_demo():
-    """Interactive multi-agent research terminal with proper workflow management."""
-    print("🎯 Deep Research Agency - Advanced Multi-Agent Research")
-    print("Multi-agent workflow: Triage → [Clarifying] → Instruction → Research")
-    print("=" * 70)
-    print("Ask any research question. Type 'quit' to exit.")
-    print("📄 Research reports will be automatically saved as PDF files.\n")
-
-    while True:
-        try:
-            query = input("🔥 Research Query: ").strip()
-            if query.lower() in ["quit", "exit", "q"]:
-                print("👋 Goodbye!")
-                break
-
-            if not query:
-                print("Please enter a research question.")
-                continue
-
-            # Initialize workflow state
-            current_agent = "Triage Agent"
-            awaiting_clarifications = False
-            clarification_questions = []
-            research_content = ""
-            agent_responses = {}  # Track responses by agent
-            clarifying_agent_text = ""  # Track text from Clarifying Agent
-
-            print(f"\n🤖 Starting with {current_agent}...")
-            print("─" * 50)
-
-            # Stream the response
-            response_stream = agency.get_response_stream(query)
-
-            async for event in response_stream:
-                # Track agent switches
-                if (
-                    hasattr(event, "type")
-                    and event.type == "agent_updated_stream_event"
-                ):
-                    if hasattr(event, "new_agent"):
-                        current_agent = event.new_agent.name
-                        print(f"\n\n🔄 Switched to: {current_agent}")
-                        print("─" * 50)
-
-                        # Show appropriate status based on agent
-                        if current_agent == "Research Agent":
-                            print(
-                                "🔬 Performing deep research... This may take a few minutes."
-                            )
-                        elif current_agent == "Clarifying Questions Agent":
-                            print("❓ Preparing clarification questions...")
-                            clarifying_agent_text = ""  # Reset to capture new text
-                        elif current_agent == "Research Instruction Agent":
-                            print("📋 Building research instructions...")
-
-                # Handle streaming events with data
-                elif hasattr(event, "data"):
-                    data = event.data
-
-                    # Track tool calls for visibility
-                    if (
-                        hasattr(data, "type")
-                        and data.type == "response.function_call_arguments.delta"
-                    ):
-                        # Don't display tool call arguments, but track if it's a web search
-                        pass
-
-                    # Handle actual response text
-                    elif hasattr(data, "delta") and hasattr(data, "type"):
-                        if data.type == "response.output_text.delta":
-                            delta_text = data.delta
-                            if delta_text:
-                                # Only print if not from Clarifying Agent (we'll handle that specially)
-                                if current_agent != "Clarifying Questions Agent":
-                                    print(delta_text, end="", flush=True)
-
-                                # Track content by agent
-                                if current_agent not in agent_responses:
-                                    agent_responses[current_agent] = ""
-                                agent_responses[current_agent] += delta_text
-
-                                # Track Clarifying Agent text separately to parse JSON
-                                if current_agent == "Clarifying Questions Agent":
-                                    clarifying_agent_text += delta_text
-
-                                # Only track research content from Research Agent
-                                if current_agent == "Research Agent":
-                                    research_content += delta_text
-
-                # Handle raw response events (for action visibility)
-                elif hasattr(event, "type") and event.type == "raw_response_event":
-                    if hasattr(event, "data") and hasattr(event.data, "item"):
-                        item = event.data.item
-                        if hasattr(item, "action"):
-                            action = item.action or {}
-                            if (
-                                action.get("type") == "search"
-                                and current_agent == "Research Agent"
-                            ):
-                                query_text = action.get("query", "")
-                                if query_text:
-                                    print(f"\n🔍 [Web Search]: {query_text}")
-
-                # Handle structured output (Clarifications) - though this might not happen in streaming
-                elif hasattr(event, "item") and isinstance(
-                    getattr(event, "item", None), Clarifications
-                ):
-                    awaiting_clarifications = True
-                    clarification_questions = event.item.questions
-
-                # Handle errors
-                elif isinstance(event, dict):
-                    event_type = event.get("event", event.get("type"))
-                    if event_type == "error":
-                        print(
-                            f"\n❌ Error: {event.get('content', event.get('data', 'Unknown error'))}"
-                        )
-                        break
-
-            # After streaming completes, check if we got clarification questions as JSON
-            if clarifying_agent_text and not clarification_questions:
-                try:
-                    import json
-
-                    # Try to parse the JSON response from Clarifying Agent
-                    clarifying_data = json.loads(clarifying_agent_text.strip())
-                    if "questions" in clarifying_data:
-                        clarification_questions = clarifying_data["questions"]
-                        awaiting_clarifications = True
-                except json.JSONDecodeError:
-                    # If not valid JSON, maybe it's formatted differently
-                    pass
-
-            # After streaming completes, check if we need clarifications
-            if awaiting_clarifications and clarification_questions:
-                print("\n\n" + "─" * 50)
-                print(
-                    "✏️ Please answer the following questions to help me research better:\n"
-                )
-
-                # Collect answers
-                answers = []
-                for i, question in enumerate(clarification_questions, 1):
-                    print(f"{i}. {question}")
-                    answer = input("   Your answer: ").strip()
-                    if not answer:
-                        answer = "No preference."
-                    answers.append(f"**{question}**\n{answer}")
-
-                # Send clarification responses
-                print("\n🔄 Processing your answers...")
-                print("─" * 50)
-
-                # Reset state for the follow-up
-                current_agent = "Clarifying Questions Agent"
-                awaiting_clarifications = False
-                clarification_questions = []
-                research_content = ""  # Reset until we get to Research Agent
-
-                # Continue with clarification responses
-                clarification_response = "\n\n".join(answers)
-
-                async for event in agency.get_response_stream(clarification_response):
-                    # Same event handling as above
-                    if (
-                        hasattr(event, "type")
-                        and event.type == "agent_updated_stream_event"
-                    ):
-                        if hasattr(event, "new_agent"):
-                            current_agent = event.new_agent.name
-                            print(f"\n\n🔄 Switched to: {current_agent}")
-                            print("─" * 50)
-
-                            if current_agent == "Research Instruction Agent":
-                                print("📋 Building research instructions...")
-                            elif current_agent == "Research Agent":
-                                print(
-                                    "🔬 Performing deep research... This may take a few minutes."
-                                )
-
-                    elif hasattr(event, "data"):
-                        data = event.data
-
-                        if hasattr(data, "delta") and hasattr(data, "type"):
-                            if data.type == "response.output_text.delta":
-                                delta_text = data.delta
-                                if delta_text:
-                                    print(delta_text, end="", flush=True)
-
-                                    if current_agent == "Research Agent":
-                                        research_content += delta_text
-
-                    elif hasattr(event, "type") and event.type == "raw_response_event":
-                        if hasattr(event, "data") and hasattr(event.data, "item"):
-                            item = event.data.item
-                            if hasattr(item, "action"):
-                                action = item.action or {}
-                                if (
-                                    action.get("type") == "search"
-                                    and current_agent == "Research Agent"
-                                ):
-                                    query_text = action.get("query", "")
-                                    if query_text:
-                                        print(f"\n🔍 [Web Search]: {query_text}")
-
-            # Save PDF only if we have research content from Research Agent
-            if research_content.strip():
-                print("\n\n" + "─" * 50)
-                save_response_to_pdf(research_content, query)
-            else:
-                print("\n\n⚠️ No research content generated. PDF not saved.")
-
-            print("\n" + "=" * 70)  # Separator for next query
-
-        except KeyboardInterrupt:
-            print("\n👋 Goodbye!")
-            break
-        except Exception as e:
-            # Suppress MockValSer conversion errors that happen after streaming completes
-            error_msg = str(e)
-            if "MockValSer" in error_msg and "to_input_item" in error_msg:
-                # This is a known issue with agency_swarm streaming - ignore it
-                pass
-            else:
-                print(f"\n❌ Error: {e}")
-                import traceback
-
-                traceback.print_exc()
-
-
-def copilot_demo():
-    """Launch Copilot UI demo with PDF generation wrapper."""
-    print("🎯 Starting Copilot UI with automatic PDF generation...")
-    print("📄 All research reports will be automatically saved as PDF files.")
-
-    try:
-        from agency_swarm.ui.demos.launcher import CopilotDemoLauncher
-
-        # Create a wrapper agency that saves to PDF
-        class PDFSavingAgency(Agency):
-            def get_response(self, query: str, **kwargs):
-                response = super().get_response(query, **kwargs)
-                save_response_to_pdf(response, query)
-                return response
-
-        # Create PDF-saving version of the agency
-        pdf_agency = PDFSavingAgency(triage_agent)
-
-        launcher = CopilotDemoLauncher()
-        launcher.start(pdf_agency)
-
-    except ImportError:
-        print("❌ Copilot demo requires additional dependencies")
-        print("Install with: pip install agency-swarm[copilot]")
-
-
 if __name__ == "__main__":
     import asyncio
     import sys
 
     if len(sys.argv) > 1 and sys.argv[1] in ["--ui", "--copilot"]:
         print("🚀 Launching Copilot UI...")
-        copilot_demo()
+        copilot_demo(agency, save_response_to_pdf)
     else:
         print("🚀 Launching Terminal Demo...")
-        asyncio.run(stream_demo())
+        asyncio.run(stream_demo(agency, save_response_to_pdf))

--- a/demo_utils.py
+++ b/demo_utils.py
@@ -1,0 +1,141 @@
+import json
+from typing import Callable, List, Tuple
+
+from agency_swarm import Agency
+
+
+def _print_debug(event, seen):
+    event_type = getattr(event, "type", None)
+    if event_type and event_type not in seen and event_type != "response.output_text.delta":
+        print(f"\n[DEBUG] {event_type}")
+        seen.add(event_type)
+
+
+async def stream_response(
+    agency: Agency, message: str, debug: bool = False
+) -> Tuple[str, List[str]]:
+    """Stream a response from an agency with optional debug logging."""
+    print(f"\n🔥 Streaming: {message}")
+    print("📡 Response: ", end="", flush=True)
+
+    full_text = ""
+    clarification_questions: List[str] = []
+    clarifying_text = ""
+    current_agent = None
+    seen_events = set()
+
+    async for event in agency.get_response_stream(message):
+        if debug:
+            _print_debug(event, seen_events)
+
+        if getattr(event, "type", None) == "agent_updated_stream_event" and hasattr(event, "new_agent"):
+            current_agent = event.new_agent.name
+            print(f"\n\n🔄 Switched to: {current_agent}")
+            print("─" * 50)
+            continue
+
+        if hasattr(event, "data"):
+            data = event.data
+            if getattr(data, "type", "") == "response.output_text.delta":
+                delta = getattr(data, "delta", "")
+                if delta:
+                    if current_agent != "Clarifying Questions Agent":
+                        print(delta, end="", flush=True)
+                    if current_agent == "Clarifying Questions Agent":
+                        clarifying_text += delta
+                    if current_agent == "Research Agent" or not current_agent:
+                        full_text += delta
+            elif getattr(data, "type", "") == "response.function_call_arguments.delta" and debug:
+                print(f"\n[DEBUG] Tool call: {data.delta}")
+
+        elif getattr(event, "type", None) == "raw_response_event":
+            if hasattr(event, "data") and hasattr(event.data, "item"):
+                action = getattr(event.data.item, "action", {}) or {}
+                if action.get("type") == "search" and current_agent == "Research Agent":
+                    query_text = action.get("query", "")
+                    if query_text:
+                        print(f"\n🔍 [Web Search]: {query_text}")
+
+        elif hasattr(event, "item") and hasattr(event.item, "questions"):
+            clarification_questions = list(event.item.questions)
+
+        elif isinstance(event, dict) and event.get("event") == "error":
+            print(f"\n❌ Error: {event.get('content', event.get('data', 'Unknown'))}")
+            break
+
+    if clarifying_text and not clarification_questions:
+        try:
+            data = json.loads(clarifying_text.strip())
+            clarification_questions = data.get("questions", [])
+        except json.JSONDecodeError:
+            pass
+
+    print("\n✅ Stream complete")
+    return full_text, clarification_questions
+
+
+async def stream_demo(
+    agency: Agency,
+    save_pdf: Callable[[str, str], str] | None = None,
+    debug: bool = False,
+):
+    """Interactive terminal demo for any research agency."""
+    print("🌟 Research Agency Demo")
+    print("Ask any research question. Type 'quit' to exit.\n")
+
+    while True:
+        try:
+            query = input("🔥 Research Query: ").strip()
+            if query.lower() in ["quit", "exit", "q"]:
+                print("👋 Goodbye!")
+                break
+
+            if not query:
+                continue
+
+            response_text, questions = await stream_response(agency, query, debug)
+
+            if questions:
+                print("\n✏️ Please answer the following questions:\n")
+                answers = []
+                for q in questions:
+                    ans = input(f"{q}\n   Your answer: ").strip() or "No preference."
+                    answers.append(f"**{q}**\n{ans}")
+                follow_text, _ = await stream_response(agency, "\n\n".join(answers), debug)
+                response_text += follow_text
+
+            if save_pdf and response_text.strip():
+                pdf = save_pdf(response_text, query)
+                print(f"\n📄 Research report saved to: {pdf}")
+
+            print("\n" + "=" * 70)
+
+        except KeyboardInterrupt:
+            print("\n👋 Goodbye!")
+            break
+        except Exception as e:
+            print(f"\n❌ Error: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+
+def copilot_demo(agency: Agency, save_pdf: Callable[[str, str], str] | None = None):
+    """Launch Copilot UI demo with optional PDF saving."""
+    try:
+        from agency_swarm.ui.demos.launcher import CopilotDemoLauncher
+
+        if save_pdf:
+            class PDFSavingAgency(Agency):
+                def get_response(self, query: str, **kwargs):
+                    response = super().get_response(query, **kwargs)
+                    save_pdf(str(response), query)
+                    return response
+
+            agency = PDFSavingAgency(agency.entry_agent)
+
+        launcher = CopilotDemoLauncher()
+        launcher.start(agency)
+    except ImportError:
+        print("❌ Copilot demo requires additional dependencies")
+        print("Install with: pip install agency-swarm[copilot]")


### PR DESCRIPTION
## Summary
- extract streaming demo helpers to `demo_utils.py`
- import helper functions in both agencies
- shrink agency scripts to remain under 200 lines
- ensure repo root is on `sys.path` for deep agency

## Testing
- `pip install -q agency-swarm==1.0.0b3`
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: Expected None but test returned True)*
- `python BasicResearchAgency/agency.py <<'EOF'
What is the capital of France?
quit
EOF`
- `python DeepResearchAgency/agency.py <<'EOF'
What is AI?
quit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6866ab425ce083238f9a2b212872b64c